### PR TITLE
add table/array perf checking

### DIFF
--- a/data/expression2/tests/regressions/3325.txt
+++ b/data/expression2/tests/regressions/3325.txt
@@ -1,0 +1,65 @@
+## SHOULD_PASS:EXECUTE
+
+# Tables
+
+let A = table(1, 2, 3, "four", vec(5))
+
+let B = table(1 = 1, 2 = 2, 3 = 3, 4 = "four", 5 = vec(5))
+
+let Count = 0
+
+function err(K:number, X:string, V:string) {
+    return format("Failed at key %d with values [%s, %s]", K, X, V)
+}
+
+foreach(K:number, V:number = B) {
+    Count += K
+    let X = A[K, number]
+    assert(X == V, err(K, toString(X), toString(V)))
+}
+
+assert(Count == 6)
+
+foreach(K:number, V:string = B) {
+    Count += K
+    let X = A[K, string]
+    assert(X == V, err(K, X, V))
+}
+
+assert(Count == 10)
+
+foreach(K:number, V:vector = B) {
+    Count += K
+    let X = A[K, vector]
+    assert(X == V, err(K, toString(X), toString(V)))
+}
+
+assert(Count == 15)
+
+# Arrays
+
+let C = array(1, 2, 3, "four", vec(5))
+
+let D = array(1 = 1, 2 = 2, 3 = 3, 4 = "four", 5 = vec(5))
+
+Count = 0
+
+foreach(K:number, V:number = D) {
+    Count += K
+    let X = C[K, number]
+    assert(X == V, err(K, toString(X), toString(V)))
+}
+
+assert(Count == 6)
+
+if(1) {
+    let X = C[4, string]
+    let V = D[4, string]
+    assert(X == V, err(4, X, V))
+}
+
+if(1) {
+    let X = C[5, vector]
+    let V = D[5, vector]
+    assert(X == V, err(5, toString(X), toString(V)))
+}

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -923,6 +923,13 @@ function Parser:Expr15()
 
 	local fn = self:Consume(TokenVariant.LowerIdent)
 	if fn then
+		-- Transform key value
+		if fn.value == "array" then
+			return Node.new(NodeVariant.ExprArray, self:ArgumentsKV(Grammar.LParen, Grammar.RParen) or self:Arguments(), fn.trace:stitch(self:Prev().trace))
+		elseif fn.value == "table" then
+			return Node.new(NodeVariant.ExprTable, self:ArgumentsKV(Grammar.LParen, Grammar.RParen) or self:Arguments(), fn.trace:stitch(self:Prev().trace))
+		end
+
 		return Node.new(NodeVariant.ExprCall, { fn, self:Arguments() }, fn.trace:stitch(self:Prev().trace))
 	end
 


### PR DESCRIPTION
- Adds perf check to table/array constructor loops
- Adds test file

From here, I think what's left is deleting(?) or at least makings stubs of the table and array constructors.

I figured it'd just be easier PR'ing here than trying to compete with two different PRs on main but idk.

One reason I do *not* want to redirect constructors to the e2functions is because the compiler does micro-optimizations based on the structure of its inputs (e.g., for arrays and tables without KV, it uses ipairs). I'm not sure how to approach this better :P. I would like to use the e2functions, but it would break the API a bit and it just seems even more hacky than what we have now.